### PR TITLE
Slurm resource defaults

### DIFF
--- a/ansible/templates/slurm.conf.j2
+++ b/ansible/templates/slurm.conf.j2
@@ -51,7 +51,7 @@ JobFileAppend=1
 # Fallback memory allocation values
 DefMemPerCPU=3800
 DefMemPerGPU=40000
-DefCpuPerGpu=10
+DefCpuPerGpu=6
 
 {% if slurm_include_pmix %}
 # Use PMIX as our default MPI configuration

--- a/ansible/templates/slurm.conf.j2
+++ b/ansible/templates/slurm.conf.j2
@@ -48,6 +48,10 @@ RebootProgram="{{ slurm_reboot_program }}"
 ResumeTimeout={{ slurm_resume_timeout }}
 JobFileAppend=1
 
+# Fallback memory allocation values
+DefMemPerCPU=3800
+DefMemPerGPU=40000
+DefCpuPerGpu=10
 
 {% if slurm_include_pmix %}
 # Use PMIX as our default MPI configuration


### PR DESCRIPTION
This sets better default values for memory and CPU cores allocated to jobs if users do not specify it themselves.  
This also takes #22 into account.  
To be deployed on the 13th of February.