### PR TITLE
Make "prioritized" partition the default

### DIFF
--- a/ansible/templates/slurm.conf.d/aicloud.conf
+++ b/ansible/templates/slurm.conf.d/aicloud.conf
@@ -1,5 +1,5 @@
-PartitionName=batch PriorityTier=0 Nodes=ALL Default=YES State=UP OverSubscribe=NO MaxTime=12:00:00
-PartitionName=prioritized PriorityTier=10 AllowGroups=ai-pilot-user@srv.aau.dk OverSubscribe=NO Nodes=a256-a40-04.srv.aau.dk,a256-a40-05.srv.aau.dk,a256-a40-06.srv.aau.dk,a256-a40-07.srv.aau.dk,a256-t4-02.srv.aau.dk,a256-t4-03.srv.aau.dk,i256-a10-06.srv.aau.dk,i256-a10-07.srv.aau.dk,i256-a10-08.srv.aau.dk,i256-a10-09.srv.aau.dk,i256-a10-10.srv.aau.dk,nv-ai-01.srv.aau.dk,nv-ai-02.srv.aau.dk,nv-ai-03.srv.aau.dk MaxTime=6-00:00:00
+PartitionName=batch PriorityTier=0 Nodes=ALL State=UP OverSubscribe=NO MaxTime=12:00:00
+PartitionName=prioritized Default=YES PriorityTier=10 AllowGroups=ai-pilot-user@srv.aau.dk OverSubscribe=NO Nodes=a256-a40-04.srv.aau.dk,a256-a40-05.srv.aau.dk,a256-a40-06.srv.aau.dk,a256-a40-07.srv.aau.dk,a256-t4-02.srv.aau.dk,a256-t4-03.srv.aau.dk,i256-a10-06.srv.aau.dk,i256-a10-07.srv.aau.dk,i256-a10-08.srv.aau.dk,i256-a10-09.srv.aau.dk,i256-a10-10.srv.aau.dk,nv-ai-01.srv.aau.dk,nv-ai-02.srv.aau.dk,nv-ai-03.srv.aau.dk MaxTime=6-00:00:00
 PartitionName=create PriorityTier=10 AllowGroups=ai-create-user@srv.aau.dk OverSubscribe=NO Nodes=nv-ai-04.srv.aau.dk MaxTime=INFINITE
 PartitionName=aicentre1 PriorityTier=10 AllowGroups=ai-aicentre1-user@srv.aau.dk OverSubscribe=NO Nodes=i256-a40-01.srv.aau.dk MaxTime=INFINITE
 PartitionName=aicentre2 PriorityTier=10 AllowGroups=ai-aicentre2-user@srv.aau.dk OverSubscribe=NO Nodes=i256-a40-02.srv.aau.dk MaxTime=INFINITE


### PR DESCRIPTION
I propose to make "prioritized" the default partition instead of "batch".

**Background:** The cluster was originally set up with the intent to have most users using the "batch" partition (where they cannot preempt each other). Users should get used to short run-times and learn to work with check-pointing in their workloads and requeue their jobs automatically. The "prioritized" partition could then be used for special cases where few users have an urgent need to run something NOW (jobs in "prioritized" can preempt jobs in "batch").

**Problem:** We have so far not realised the original intent of the partitions and have ended up increasing the max. run-time to 6 days in "prioritised" and letting everyone use this partition to avoid interruptions. Users who are not aware of the characteristics - or even existence - of the partitions "batch" and "prioritized" by default end up running jobs in the batch partition. Here they are often preempted by jobs in the prioritized partition, to much frustration.

**Solution:** By making "prioritized" the default partition for now, users by default avoid the pre-emption issue. Users only need to know about the "batch" partition if they need to use the "private" nodes (nv-ai-04, i256-a40-01/-02).  
We can still work towards the original goal with the partitions and change max. run-times and default status at a later stage.